### PR TITLE
rework health and arming protocol: separate can_arm from can_run

### DIFF
--- a/libs/cpp/parse/health_and_arming_checks.h
+++ b/libs/cpp/parse/health_and_arming_checks.h
@@ -37,7 +37,8 @@ public:
     };
     struct ModeGroup {
         std::string name;
-        bool can_arm_and_run{false};
+        bool can_arm{false};  ///< whether or not arming is possible for this mode group
+        bool can_run{false};  ///< whether or not it's possible to switch to these modes (only relevant while armed)
     };
     struct ModeGroups {
         std::vector<ModeGroup> groups;
@@ -58,7 +59,8 @@ public:
     class Results
     {
     public:
-        bool canArmAndRun(int mode_group_index) const;
+        bool canArm(int mode_group_index) const;
+        bool canRun(int mode_group_index) const;
 
         const std::vector<Check>& checks() const { return _checks; }
         std::vector<Check> checks(int mode_group_index) const;

--- a/libs/python/tests/health_and_arming_checks.py
+++ b/libs/python/tests/health_and_arming_checks.py
@@ -39,9 +39,10 @@ print('No Events')
 chunk_id = 0
 error = 0
 warning = gps_mask
-can_arm_and_run = pos_ctrl_mask | rtl_mask
+can_arm = pos_ctrl_mask | rtl_mask
+can_run = 0
 args = create_args([(chunk_id, 'int8_t'), (error, 'uint32_t'), (warning, 'uint32_t'),
-                    (can_arm_and_run, 'uint32_t')])
+                    (can_arm, 'uint32_t'), (can_run, 'uint32_t')])
 event_id = 11047904 | (0 << 24) # arming check summary
 parsed_event = p.parse(event_id, args)
 assert parsed_event
@@ -72,10 +73,10 @@ assert health_and_arming_checks.results.health_components['gps'].health.is_prese
 assert not health_and_arming_checks.results.health_components['absolute_pressure'].health.error
 assert health_and_arming_checks.results.health_components['absolute_pressure'].health.warning
 assert health_and_arming_checks.results.health_components['absolute_pressure'].health.is_present
-assert not health_and_arming_checks.results.can_arm_and_run(int(math.log2(manual_mask)))
-assert health_and_arming_checks.results.can_arm_and_run(int(math.log2(pos_ctrl_mask)))
-assert not health_and_arming_checks.results.can_arm_and_run(int(math.log2(mission_mask)))
-assert health_and_arming_checks.results.can_arm_and_run(int(math.log2(rtl_mask)))
+assert not health_and_arming_checks.results.can_arm(int(math.log2(manual_mask)))
+assert health_and_arming_checks.results.can_arm(int(math.log2(pos_ctrl_mask)))
+assert not health_and_arming_checks.results.can_arm(int(math.log2(mission_mask)))
+assert health_and_arming_checks.results.can_arm(int(math.log2(rtl_mask)))
 print("")
 
 
@@ -175,9 +176,10 @@ print("Adding chunk")
 chunk_id = 1
 error = 0
 warning = differential_pressure_mask
-can_arm_and_run = pos_ctrl_mask
+can_arm = pos_ctrl_mask
+can_run = pos_ctrl_mask
 args = create_args([(chunk_id, 'int8_t'), (error, 'uint32_t'), (warning, 'uint32_t'),
-                    (can_arm_and_run, 'uint32_t')])
+                    (can_arm, 'uint32_t'), (can_run, 'uint32_t')])
 event_id = 11047904 | (0 << 24) # arming check summary
 parsed_event = p.parse(event_id, args)
 assert parsed_event
@@ -215,10 +217,10 @@ assert health_and_arming_checks.results.health_components['absolute_pressure'].h
 assert health_and_arming_checks.results.health_components['absolute_pressure'].health.is_present
 assert health_and_arming_checks.results.health_components['differential_pressure']\
     .arming_check.warning
-assert not health_and_arming_checks.results.can_arm_and_run(int(math.log2(manual_mask)))
-assert health_and_arming_checks.results.can_arm_and_run(int(math.log2(pos_ctrl_mask)))
-assert not health_and_arming_checks.results.can_arm_and_run(int(math.log2(mission_mask)))
-assert not health_and_arming_checks.results.can_arm_and_run(int(math.log2(rtl_mask)))
+assert not health_and_arming_checks.results.can_arm(int(math.log2(manual_mask)))
+assert health_and_arming_checks.results.can_arm(int(math.log2(pos_ctrl_mask)))
+assert not health_and_arming_checks.results.can_arm(int(math.log2(mission_mask)))
+assert not health_and_arming_checks.results.can_arm(int(math.log2(rtl_mask)))
 
 assert len(removed_events) == 0
 assert len(added_events) == 1

--- a/libs/test.json
+++ b/libs/test.json
@@ -166,7 +166,11 @@
                                 },
                                 {
                                     "type": "test2::navigation_mode_group_t",
-                                    "name": "can_arm_and_run"
+                                    "name": "can_arm"
+                                },
+                                {
+                                    "type": "test2::navigation_mode_group_t",
+                                    "name": "can_run"
                                 }
                             ]
                         },

--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -213,7 +213,8 @@ def validate_group(event, group_name, event_name, arguments):
                 validate_arg_name(event, arguments, 1, 'error')
                 validate_arg_name(event, arguments, 2, 'warning')
                 validate_arg_type(event, arguments, 2, arguments[1])
-                validate_arg_name(event, arguments, 3, 'can_arm_and_run')
+                validate_arg_name(event, arguments, 3, 'can_arm')
+                validate_arg_name(event, arguments, 4, 'can_run')
             else: # 'health'
                 validate_arg_name(event, arguments, 1, 'is_present')
                 validate_arg_name(event, arguments, 2, 'error')


### PR DESCRIPTION
Follow-up from https://github.com/mavlink/libevents/pull/2

Requires one more argument, but with the combined version, the autopilot
was forced to send an update on each arming & disarming event if the values
are different.