### PR TITLE
Changed nlohman_json library orignal and bumped up version

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "libs/cpp/parse/nlohmann_json"]
 	path = libs/cpp/parse/nlohmann_json
-	url = https://github.com/ArthurSonzogni/nlohmann_json_cmake_fetchcontent.git
+	url = https://github.com/nlohmann/json.git

--- a/libs/cpp/parse/parser.cpp
+++ b/libs/cpp/parse/parser.cpp
@@ -6,7 +6,7 @@
 #include <iomanip>
 #include <sstream>
 
-#include "nlohmann_json/include/nlohmann/json.hpp"
+#include "nlohmann_json/single_include/nlohmann/json.hpp"
 
 using json = nlohmann::json;
 using namespace std;

--- a/libs/cpp/parse/parser.h
+++ b/libs/cpp/parse/parser.h
@@ -10,7 +10,7 @@
 #include <string>
 #include <vector>
 
-#include "nlohmann_json/include/nlohmann/json_fwd.hpp"
+#include "nlohmann_json/single_include/nlohmann/json_fwd.hpp"
 
 namespace events
 {


### PR DESCRIPTION
The MR changes the nlohmann_json library from https://github.com/ArthurSonzogni/nlohmann_json_cmake_fetchcontent.git to https://github.com/nlohmann/json.git and bumps up to the latest version v3.11.2. These changes were made to fix compilation issues with gcc-11 regarding the violation of the one definition rule.