### PR TITLE
Fix cmake_minimum_required

### DIFF
--- a/libs/cpp/CMakeLists.txt
+++ b/libs/cpp/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.19)
 
 if (POLICY CMP0048)
 	cmake_policy(SET CMP0048 NEW)


### PR DESCRIPTION
Using [add_library](https://cmake.org/cmake/help/latest/command/add_library.html#interface-with-sources) with sources for interface libraries has been added in CMake 3.19.

More specifically, [this](https://github.com/mavlink/libevents/blob/main/libs/cpp/common/CMakeLists.txt#L3-L5) seems to fail with older CMake versions:

```cmake
add_library(libevents_common INTERFACE
	event_type.h
)
```

Therefore it seems like `cmake_minimum_required` should be set to at least 3.19.

(Seen in https://github.com/mavlink/MAVSDK/issues/2374#issuecomment-2292385632)