### PR TITLE
Fix python3 executable path

### DIFF
--- a/libs/cpp/tests/CMakeLists.txt
+++ b/libs/cpp/tests/CMakeLists.txt
@@ -15,9 +15,10 @@ FetchContent_MakeAvailable(googletest)
 
 enable_testing()
 
+find_package(Python3 COMPONENTS Interpreter)
 set(generated_events_header ${CMAKE_CURRENT_BINARY_DIR}/events_generated.h)
 add_custom_command(OUTPUT ${generated_events_header}
-	COMMAND ${PYTHON_EXECUTABLE} ${LIBEVENTS_ROOT_DIR}/scripts/generate.py
+	COMMAND ${Python3_EXECUTABLE} ${LIBEVENTS_ROOT_DIR}/scripts/generate.py
 		--language cpp
 		--output ${CMAKE_CURRENT_BINARY_DIR}
 		${LIBEVENTS_ROOT_DIR}/libs/test.json

--- a/scripts/generate.py
+++ b/scripts/generate.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
     Script to generate code from jinja2 templates and an event file

--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
     Script to validate event definition files


### PR DESCRIPTION
Fixes build errors encountered in Dockerized environment.

We now use the [FindPython3](https://cmake.org/cmake/help/v3.21/module/FindPython3.html?highlight=python3) module.
Python2, and the path to `/usr/bin/python` is not installed on Ubuntu 22 or later.

I encountered build problems here: https://github.com/mavlink/MAVSDK/issues/2691#issuecomment-3492498809



Tested with this dockerfile:
```docker
FROM ubuntu:22.04

WORKDIR /ws

# https://mavsdk.mavlink.io/main/en/cpp/guide/build_linux.html

RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
    --mount=target=/var/cache/apt,type=cache,sharing=locked \
    apt-get update && \
    DEBIAN_FRONTEND=noninteractive apt-get -y install \
        build-essential \
        cmake \
        git \
        python3 \
        python3-pip

COPY . .
RUN python3 -m pip install -r requirements.txt
RUN cmake -B build -S libs/cpp
RUN cmake --build build
RUN cmake --install build --prefix install
```

I am not sure how/why CI is currently working. Maybe it isn't on Ubuntu:22.

