### PR TITLE
Remove unnecessary nlohmann_json target to avoid namespace conflicts

### DIFF
--- a/libs/cpp/parse/CMakeLists.txt
+++ b/libs/cpp/parse/CMakeLists.txt
@@ -20,16 +20,8 @@ install(TARGETS libevents_parser
 		LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
 		PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/libevents/parse)
 
-add_library(nlohmann_json
-		INTERFACE
-		nlohmann/json_fwd.hpp
-)
-set_target_properties(nlohmann_json PROPERTIES PUBLIC_HEADER
-		nlohmann/json_fwd.hpp)
-install(TARGETS nlohmann_json
-		EXPORT libevents
-		LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-		PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/libevents/parse/nlohmann)
+install(FILES nlohmann/json_fwd.hpp
+		DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/libevents/parse/nlohmann)
 
 add_library(libevents_health_and_arming_checks
 	health_and_arming_checks.cpp


### PR DESCRIPTION
**Issue:**
Compiling mavsdk with `-DBUILD_SHARED_LIBS=OFF` option and fetching `nlohmann_json` in the main project causes a cmake target name conflict error.

The actual config is creating a target in the global namespace but is not exposing the library to the consumer.

**Fix**
Replaced the target with `install` since it was used only to install a header file.